### PR TITLE
Feature/phase 1 terraform backend: Implement Terraform S3 backend with DynamoDB locking

### DIFF
--- a/scripts/setup-backend.sh
+++ b/scripts/setup-backend.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# scripts/setup-backend.sh
+
+set -e
+
+# Get the S3 bucket name from the backend outputs
+BUCKET_NAME=$(cd terraform/backend && terraform output -raw s3_bucket_name)
+DYNAMODB_TABLE=$(cd terraform/backend && terraform output -raw dynamodb_table_name)
+REGION=$(cd terraform/backend && terraform output -raw s3_bucket_region)
+
+# Create backend.tf files for each environment
+for env in dev staging prod; do
+  cat > terraform/environments/$env/backend.tf << EOFF
+terraform {
+  backend "s3" {
+    bucket         = "${BUCKET_NAME}"
+    key            = "${env}/terraform.tfstate"
+    region         = "${REGION}"
+    dynamodb_table = "${DYNAMODB_TABLE}"
+    encrypt        = true
+    profile        = "vpn-project"
+  }
+}
+EOFF
+done
+
+echo "Backend configuration files created successfully!"
+echo "S3 Bucket: $BUCKET_NAME"
+echo "DynamoDB Table: $DYNAMODB_TABLE"
+echo "Region: $REGION"

--- a/terraform/backend/dynamodb.tf
+++ b/terraform/backend/dynamodb.tf
@@ -1,0 +1,16 @@
+resource "aws_dynamodb_table" "terraform_state_lock" {
+  name =  "vpn-cluster-tfstate-lock"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = {
+    Name        = "Terraform State Lock"
+    Environment = "Global"
+    Project     = "VPN-Cluster"
+  }
+}

--- a/terraform/backend/main.tf
+++ b/terraform/backend/main.tf
@@ -25,7 +25,7 @@ resource "aws_s3_bucket" "terraform_state" {
 resource "aws_s3_bucket_versioning" "terraform_state_versioning" {
   bucket = aws_s3_bucket.terraform_state.id
   versioning_configuration {
-    status = "Enable"
+    status = "Enabled"
   }
 }
 

--- a/terraform/backend/outputs.tf
+++ b/terraform/backend/outputs.tf
@@ -1,0 +1,14 @@
+output "s3_bucket_name" {
+  value = aws_s3_bucket.terraform_state.id
+  description = "The name of the S3 bucket for Terrfaorm state"
+}
+
+output "dynamodb_table_name" {
+  value = aws_dynamodb_table.terraform_state_lock.name
+  description = "The name of the DynamoDB table for state locking"
+}
+
+output "s3_bucket_region" {
+  value = aws_s3_bucket.terraform_state.region
+  description = "The AWS region of the S3 bucket"
+}

--- a/terraform/backend/variables.tf
+++ b/terraform/backend/variables.tf
@@ -1,0 +1,17 @@
+variable "aws_region" {
+  description = "AWS region for backend resources"
+  type = string
+  default = "ap-northeast-1"
+}
+
+variable "project_name" {
+  description = "Name of the project"
+  type = string
+  default = "vpn-cluster"
+}
+
+variable "environment" {
+  description = "Environment name"
+  type = string
+  default = "global"
+}

--- a/terraform/environments/dev/backend.tf
+++ b/terraform/environments/dev/backend.tf
@@ -1,0 +1,10 @@
+terraform {
+  backend "s3" {
+    bucket         = "vpn-cluster-tfstate-afg1g47o"
+    key            = "dev/terraform.tfstate"
+    region         = "ap-northeast-1"
+    dynamodb_table = "vpn-cluster-tfstate-lock"
+    encrypt        = true
+    profile        = "vpn-project"
+  }
+}

--- a/terraform/environments/prod/backend.tf
+++ b/terraform/environments/prod/backend.tf
@@ -1,0 +1,10 @@
+terraform {
+  backend "s3" {
+    bucket         = "vpn-cluster-tfstate-afg1g47o"
+    key            = "prod/terraform.tfstate"
+    region         = "ap-northeast-1"
+    dynamodb_table = "vpn-cluster-tfstate-lock"
+    encrypt        = true
+    profile        = "vpn-project"
+  }
+}

--- a/terraform/environments/staging/backend.tf
+++ b/terraform/environments/staging/backend.tf
@@ -1,0 +1,10 @@
+terraform {
+  backend "s3" {
+    bucket         = "vpn-cluster-tfstate-afg1g47o"
+    key            = "staging/terraform.tfstate"
+    region         = "ap-northeast-1"
+    dynamodb_table = "vpn-cluster-tfstate-lock"
+    encrypt        = true
+    profile        = "vpn-project"
+  }
+}


### PR DESCRIPTION
Here's the English version of your pull request description:

## What
- S3 bucket configuration (versioning, encryption, public access blocking)
- DynamoDB table setup (for state locking)
- Backend configuration script
- Backend configuration files for each environment

## Why
- Secure management of Terraform state files
- Implementation of locking mechanism to prevent conflicts between team members
- Version history retention for infrastructure state