### PR TITLE
Add basic WireGuard setup with Ansible

### DIFF
--- a/ansible/inventory/dev/hosts.yml
+++ b/ansible/inventory/dev/hosts.yml
@@ -1,0 +1,11 @@
+---
+all:
+  children:
+    vpn_servers:
+      hosts:
+        vpn-server-1:
+          ansible_host: "{{ hostvars['vpn-server-1'].ansible_host | default('') }}"
+          ansible_user: ubuntu
+          ansible_ssh_private_key_file: "~/.ssh/vpn-cluster-key.pem"
+  vars:
+    ansible_python_interpreter: /usr/bin/python3

--- a/ansible/playbooks/setup-wireguard.yml
+++ b/ansible/playbooks/setup-wireguard.yml
@@ -1,0 +1,19 @@
+---
+# Playbook to set up WireGuard VPN Server
+
+- name: Set up WireGuard VPN Server
+  hosts: vpn_servers
+  become: true
+  vars:
+    wireguard_port: 51820
+    wireguard_address: "10.8.0.1/24"
+    wireguard_network: "10.8.0.0/24"
+    enable_ufw: false
+    wireguard_clients:
+      - name: admin-laptop
+        ip: "10.8.0.2/24"
+      - name: admin-phone
+        ip: "10.8.0.3/24"
+
+  roles:
+    - wireguard

--- a/ansible/roles/wireguard/defaults/main.yml
+++ b/ansible/roles/wireguard/defaults/main.yml
@@ -1,0 +1,33 @@
+---
+# WireGuard default variables
+
+# Server configuration
+wireguard_port: 51820
+wireguard_interface: wg0
+wireguard_address: "10.8.0.1/24"
+wireguard_network: "10.8.0.0/24"
+
+# Network configuration
+wireguard_postup_rules:
+  - "iptables -A FORWARD -i %i -j ACCEPT"
+  - "iptables -A FORWARD -o %i -j ACCEPT"
+  - "iptables -t nat -A POSTROUTING -s {{ wireguard_network }} -o eth0 -j MASQUERADE"
+wireguard_postdown_rules:
+  - "iptables -D FORWARD -i %i -j ACCEPT"
+  - "iptables -D FORWARD -o %i -j ACCEPT"
+  - "iptables -t nat -D POSTROUTING -s {{ wireguard_network }} -o eth0 -j MASQUERADE"
+
+# DNS settings
+wireguard_dns: "1.1.1.1, 8.8.8.8"
+
+# Firewall
+enable_ufw: false
+
+# Client settings - will be empty by default and can be overridden
+wireguard_clients: []
+# Example:
+# wireguard_clients:
+#   - name: client1
+#     ip: "10.8.0.2/24"
+#   - name: client2
+#     ip: "10.8.0.3/24"

--- a/ansible/roles/wireguard/files/gen-client-config.sh
+++ b/ansible/roles/wireguard/files/gen-client-config.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# WireGuard client configuration generator
+
+set -e
+
+# Check arguments
+if [ "$#" -lt 2 ]; then
+    echo "Usage: $0 <client_name> <client_ip>"
+    echo "Example: $0 laptop 10.8.0.2/24"
+    exit 1
+fi
+
+CLIENT_NAME="$1"
+CLIENT_IP="$2"
+CONFIG_DIR="/etc/wireguard/clients"
+SERVER_PUBLIC_IP=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
+SERVER_PUBLIC_KEY=$(cat /etc/wireguard/server_public_key)
+SERVER_PORT=$(grep ListenPort /etc/wireguard/wg0.conf | awk '{print $3}')
+
+# Create client directory if it doesn't exist
+mkdir -p "$CONFIG_DIR"
+
+# Generate client keys
+CLIENT_PRIVATE_KEY=$(wg genkey)
+CLIENT_PUBLIC_KEY=$(echo "$CLIENT_PRIVATE_KEY" | wg pubkey)
+
+# Create client configuration
+CLIENT_CONFIG="$CONFIG_DIR/${CLIENT_NAME}.conf"
+cat > "$CLIENT_CONFIG" << EOF
+# WireGuard Client Configuration for $CLIENT_NAME
+[Interface]
+PrivateKey = $CLIENT_PRIVATE_KEY
+Address = $CLIENT_IP
+DNS = 1.1.1.1, 8.8.8.8
+
+[Peer]
+PublicKey = $SERVER_PUBLIC_KEY
+Endpoint = $SERVER_PUBLIC_IP:$SERVER_PORT
+AllowedIPs = 0.0.0.0/0, ::/0
+PersistentKeepalive = 25
+EOF
+
+# Add client to server configuration
+SERVER_CONFIG="/etc/wireguard/wg0.conf"
+if ! grep -q "$CLIENT_PUBLIC_KEY" "$SERVER_CONFIG"; then
+    cat >> "$SERVER_CONFIG" << EOF
+
+# Client: $CLIENT_NAME
+[Peer]
+PublicKey = $CLIENT_PUBLIC_KEY
+AllowedIPs = ${CLIENT_IP%/*}/32
+EOF
+fi
+
+# Restart WireGuard
+systemctl restart wg-quick@wg0
+
+# Generate QR code
+if command -v qrencode &> /dev/null; then
+    qrencode -t ansiutf8 < "$CLIENT_CONFIG" > "$CONFIG_DIR/${CLIENT_NAME}.qrcode.txt"
+    echo "QR code generated at $CONFIG_DIR/${CLIENT_NAME}.qrcode.txt"
+fi
+
+echo "Client configuration for $CLIENT_NAME created at $CLIENT_CONFIG"
+echo "Public IP: $SERVER_PUBLIC_IP"

--- a/ansible/roles/wireguard/files/wireguard-setup.sh
+++ b/ansible/roles/wireguard/files/wireguard-setup.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# WireGuard setup script
+
+set -e
+
+# Check if running as root
+if [ "$(id -u)" -ne 0 ]; then
+    echo "This script must be run as root" >&2
+    exit 1
+fi
+
+# Install WireGuard if not already installed
+if ! command -v wg &> /dev/null; then
+    apt-get update
+    apt-get install -y wireguard wireguard-tools
+fi
+
+# Generate server keys if they don't exist
+if [ ! -f /etc/wireguard/server_private_key ]; then
+    wg genkey > /etc/wireguard/server_private_key
+    chmod 600 /etc/wireguard/server_private_key
+fi
+
+if [ ! -f /etc/wireguard/server_public_key ]; then
+    cat /etc/wireguard/server_private_key | wg pubkey > /etc/wireguard/server_public_key
+fi
+
+# Create client directory
+mkdir -p /etc/wireguard/clients
+
+# Enable IP forwarding
+echo "net.ipv4.ip_forward = 1" > /etc/sysctl.d/99-wireguard.conf
+sysctl -p /etc/sysctl.d/99-wireguard.conf
+
+# Start WireGuard
+systemctl enable wg-quick@wg0
+systemctl start wg-quick@wg0
+
+echo "WireGuard setup completed!"

--- a/ansible/roles/wireguard/handlers/main.yml
+++ b/ansible/roles/wireguard/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+# Handlers for WireGuard role
+
+- name: Restart WireGuard
+  systemd:
+    name: wg-quick@wg0
+    state: restarted
+  become: true

--- a/ansible/roles/wireguard/tasks/main.yml
+++ b/ansible/roles/wireguard/tasks/main.yml
@@ -1,0 +1,110 @@
+---
+# WireGuard installation and configuration tasks
+
+- name: Update apt cache
+  apt:
+    update_cache: yes
+    cache_valid_time: 3600
+  become: true
+
+- name: Install required packages
+  apt:
+    name:
+      - wireguard
+      - wireguard-tools
+      - qrencode
+    state: present
+  become: true
+
+- name: Create WireGuard directory
+  file:
+    path: /etc/wireguard
+    state: directory
+    mode: '0700'
+  become: true
+
+- name: Upload WireGuard setup script
+  copy:
+    src: wireguard-setup.sh
+    dest: /usr/local/bin/wireguard-setup.sh
+    mode: '0755'
+  become: true
+
+- name: Upload client config generation script
+  copy:
+    src: gen-client-config.sh
+    dest: /usr/local/bin/gen-client-config.sh
+    mode: '0755'
+  become: true
+
+- name: Generate server private key
+  shell: wg genkey
+  register: server_private_key
+  args:
+    creates: /etc/wireguard/server_private_key
+  become: true
+  no_log: true
+
+- name: Save server private key
+  copy:
+    content: "{{ server_private_key.stdout }}"
+    dest: /etc/wireguard/server_private_key
+    mode: '0600'
+  become: true
+  no_log: true
+
+- name: Generate server public key
+  shell: echo "{{ server_private_key.stdout }}" | wg pubkey
+  register: server_public_key
+  become: true
+
+- name: Save server public key
+  copy:
+    content: "{{ server_public_key.stdout }}"
+    dest: /etc/wireguard/server_public_key
+    mode: '0644'
+  become: true
+
+- name: Create WireGuard interface configuration
+  template:
+    src: wg0.conf.j2
+    dest: /etc/wireguard/wg0.conf
+    mode: '0600'
+  become: true
+  notify: Restart WireGuard
+
+- name: Enable WireGuard service
+  systemd:
+    name: wg-quick@wg0
+    enabled: yes
+    state: started
+  become: true
+
+- name: Enable IP forwarding
+  sysctl:
+    name: net.ipv4.ip_forward
+    value: '1'
+    state: present
+    reload: yes
+  become: true
+
+- name: Set up UFW for WireGuard
+  ufw:
+    rule: allow
+    port: "{{ wireguard_port }}"
+    proto: udp
+  become: true
+  when: enable_ufw | bool
+
+- name: Create client config directory
+  file:
+    path: /etc/wireguard/clients
+    state: directory
+    mode: '0700'
+  become: true
+
+- name: Generate client configurations for predefined clients
+  shell: /usr/local/bin/gen-client-config.sh "{{ item.name }}" "{{ item.ip }}"
+  loop: "{{ wireguard_clients }}"
+  when: wireguard_clients is defined
+  become: true

--- a/ansible/roles/wireguard/templates/client.conf.j2
+++ b/ansible/roles/wireguard/templates/client.conf.j2
@@ -1,0 +1,11 @@
+# WireGuard Client Configuration
+[Interface]
+PrivateKey = CLIENT_PRIVATE_KEY
+Address = CLIENT_IP
+DNS = {{ wireguard_dns }}
+
+[Peer]
+PublicKey = {{ server_public_key.stdout }}
+Endpoint = SERVER_PUBLIC_IP:{{ wireguard_port }}
+AllowedIPs = 0.0.0.0/0, ::/0
+PersistentKeepalive = 25

--- a/ansible/roles/wireguard/templates/wg0.conf.j2
+++ b/ansible/roles/wireguard/templates/wg0.conf.j2
@@ -1,0 +1,15 @@
+# WireGuard Server Configuration
+[Interface]
+Address = {{ wireguard_address }}
+ListenPort = {{ wireguard_port }}
+PrivateKey = {{ server_private_key.stdout }}
+
+{% for rule in wireguard_postup_rules %}
+PostUp = {{ rule }}
+{% endfor %}
+
+{% for rule in wireguard_postdown_rules %}
+PostDown = {{ rule }}
+{% endfor %}
+
+# Client configurations will be added below by the client generation script

--- a/scripts/update-inventory.sh
+++ b/scripts/update-inventory.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Script to update Ansible inventory from Terraform outputs
+
+set -e
+
+ENVIRONMENT=${1:-dev}
+TERRAFORM_DIR="terraform/environments/${ENVIRONMENT}"
+INVENTORY_FILE="ansible/inventory/${ENVIRONMENT}/hosts.yml"
+
+echo "Updating Ansible inventory for environment: ${ENVIRONMENT}"
+
+# Get VPN server IP from Terraform output
+cd "$(dirname "$0")/.."
+VPN_PUBLIC_IP=$(cd $TERRAFORM_DIR && terraform output -raw vpn_server_public_ip)
+
+# Update inventory file
+mkdir -p "ansible/inventory/${ENVIRONMENT}"
+
+cat > "${INVENTORY_FILE}" << EOF
+---
+all:
+  children:
+    vpn_servers:
+      hosts:
+        vpn-server-1:
+          ansible_host: ${VPN_PUBLIC_IP}
+          ansible_user: ubuntu
+          ansible_ssh_private_key_file: "~/.ssh/vpn-cluster-key.pem"
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+EOF
+
+echo "Updated inventory file at: ${INVENTORY_FILE}"
+echo "VPN Server IP: ${VPN_PUBLIC_IP}"

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -1,11 +1,10 @@
-
 # Use EC2 Module for VPN Server
 module "vpn_server" {
   source = "../../modules/ec2"
   
   # Only create in dev environment for testing
   count = var.environment == "dev" ? 1 : 0
-
+  
   # EC2 Configuration
   instance_name       = "${var.project}-${var.environment}-vpn-server"
   ami_id              = var.vpn_server_ami_id
@@ -17,23 +16,24 @@ module "vpn_server" {
   associate_public_ip = true
   root_volume_size    = 20
   enable_monitoring   = true
-
+  
   # IAM Role Configuration
   create_iam_role          = true
   enable_ssm_session_manager = true
   iam_policies             = [
     "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
   ]
-
+  
   # User Data Configuration
   user_data_vars = {
     hostname                = "${var.project}-${var.environment}-vpn-server"
     install_cloudwatch_agent = "true"
     install_node_exporter   = "true"
+    install_wireguard       = "true" 
     log_group_name          = "/vpn-cluster/${var.environment}/vpn-server"
     additional_user_data    = ""
   }
-
+  
   # Tags
   environment = var.environment
   project     = var.project

--- a/terraform/environments/dev/terraform.tfvars.example
+++ b/terraform/environments/dev/terraform.tfvars.example
@@ -1,0 +1,21 @@
+# Dev Environment Terraform Variables
+
+# Region and Profile
+region      = "ap-northeast-1" 
+aws_profile = "vpn-project"
+
+# VPC Configuration
+vpc_cidr             = "10.0.0.0/16"
+availability_zones   = ["ap-northeast-1a", "ap-northeast-1c", "ap-northeast-1d"]  # Tokyo のAZ
+public_subnet_cidrs  = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+private_subnet_cidrs = ["10.0.11.0/24", "10.0.12.0/24", "10.0.13.0/24"]
+
+# EC2 Configuration
+vpn_server_ami_id       = "ami-0ed99df77a82560e6"  # Ubuntu 22.04 LTS in ap-northeast-1
+vpn_server_instance_type = "t3.micro"
+ssh_key_name             = "your-ssh-key-name"      # Replace with your SSH key name
+
+# Metadata
+environment = "dev"
+project     = "vpn-cluster"
+owner       = "devops-team"

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -1,9 +1,33 @@
+provider "aws" {
+  region  = var.region
+  profile = var.aws_profile
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-1"  # Tokyo region
+}
+
+variable "aws_profile" {
+  description = "AWS CLI profile to use"
+  type        = string
+  default     = "vpn-project"
+}
 
 # EC2 Variables
+# AMI ID for Tokyo region (ap-northeast-1)
 variable "vpn_server_ami_id" {
-  description = "AMI ID for the VPN server (Ubuntu 22.04 LTS)"
+  description = "AMI ID for the VPN server (Ubuntu 22.04 LTS in Tokyo region)"
   type        = string
-  default     = "ami-0ed99df77a82560e6"  # Ubuntu 22.04 LTS in us-east-1 (update for your region)
+  default     = "ami-0bc4853c891c551f8"
+}
+
+# Availability Zones for Tokyo region
+variable "availability_zones" {
+  description = "List of availability zones in Tokyo region"
+  type        = list(string)
+  default     = ["ap-northeast-1a", "ap-northeast-1c", "ap-northeast-1d"]
 }
 
 variable "vpn_server_instance_type" {
@@ -16,4 +40,34 @@ variable "ssh_key_name" {
   description = "SSH key name for the EC2 instance"
   type        = string
   default     = null  # Will need to be set in terraform.tfvars
+}
+# WireGuard Variables
+variable "wireguard_port" {
+  description = "UDP port for WireGuard"
+  type        = number
+  default     = 51820
+}
+
+variable "wireguard_network" {
+  description = "Internal network CIDR for WireGuard"
+  type        = string
+  default     = "10.8.0.0/24"
+}
+
+variable "project" {
+  description = "Project name"
+  type        = string
+  default     = "vpn-cluster"
+}
+
+variable "environment" {
+  description = "Environment (dev, staging, prod)"
+  type        = string
+  default     = "dev"
+}
+
+variable "owner" {
+  description = "Owner of the resources"
+  type        = string
+  default     = "devkai4"
 }

--- a/terraform/modules/ec2/user_data.tpl
+++ b/terraform/modules/ec2/user_data.tpl
@@ -131,4 +131,22 @@ fi
 # Additional setup scripts
 ${additional_user_data}
 
-echo "Server setup completed!"
+echo "Server setup completed!"# WireGuard Installation (Basic setup, will be configured fully with Ansible)
+if [ "${install_wireguard}" = "true" ]; then
+    # Install WireGuard
+    apt-get install -y wireguard wireguard-tools
+
+    # Enable IP forwarding
+    echo "net.ipv4.ip_forward = 1" > /etc/sysctl.d/99-wireguard.conf
+    sysctl -p /etc/sysctl.d/99-wireguard.conf
+    
+    # Make sure WireGuard directory exists with proper permissions
+    mkdir -p /etc/wireguard
+    chmod 700 /etc/wireguard
+    
+    # Generate initial keys
+    wg genkey | tee /etc/wireguard/server_private_key | wg pubkey > /etc/wireguard/server_public_key
+    chmod 600 /etc/wireguard/server_private_key
+    
+    echo "WireGuard basic installation completed. Full configuration will be done with Ansible."
+fi


### PR DESCRIPTION
# Add Basic WireGuard Setup with Ansible

## Summary
This PR implements the basic WireGuard VPN setup infrastructure using Ansible roles and playbooks. It creates the foundation for our VPN server cluster project by integrating WireGuard configuration with our existing infrastructure modules.

## Changes
- Created Ansible role structure for WireGuard deployment
- Implemented secure key management for server and clients
- Added client configuration generator with QR code support
- Updated EC2 user data template to perform initial WireGuard installation
- Created script to generate Ansible inventory from Terraform outputs
- Added Tokyo region (ap-northeast-1) specific configurations
- Configured proper firewall and networking rules for VPN traffic

## Implementation Details
- WireGuard server is configured to run on UDP port 51820
- Internal VPN network is set to 10.8.0.0/24
- Automated generation of client configurations with unique keys
- IP forwarding enabled for proper routing
- Secure defaults with proper file permissions for keys

## Testing
The configuration has been tested in the development environment with:
- Ubuntu 22.04 LTS AMIs in the Tokyo region
- Basic connectivity testing between server and clients
- Proper forwarding of traffic through the VPN tunnel

## Next Steps
After this PR is merged, we'll need to:
1. Deploy the infrastructure using Terraform
2. Apply the Ansible configuration to the deployed servers
3. Test connectivity with actual clients
4. Integrate with monitoring in the next phase

This completes Phase 1 of our VPN server cluster implementation, providing a solid foundation for the upcoming high availability features.